### PR TITLE
bmcweb: bump SRCREV for Members-forward privilege fix (PR #3)

### DIFF
--- a/meta-common/recipes-phosphor/bmcweb/bmcweb_%.bbappend
+++ b/meta-common/recipes-phosphor/bmcweb/bmcweb_%.bbappend
@@ -15,7 +15,7 @@ GROUPADD_PARAM:${PN}:append = ";redfish-hostiface"
 
 SRC_URI = "git://git@github.com/ocp-hm-openbmc-opf-ami/bmcweb;protocol=https;branch=master;name=override;"
 SRCREV_FORMAT = "override"
-SRCREV_override = "9c234a8e50f0e760509324bf8ae81d1d3ae81040"
+SRCREV_override = "bf6659bd940277f2be3037a9a0800509b03e31b3"
 
 #EXTRA_OEMESON += "${@bb.utils.contains('IMAGE_FSTYPES', 'intel-pfr', '-Dintel-pfr=enabled',' ', d)}"
 #EXTRA_OEMESON += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-mgx','-Dredfish-intel-feature=enabled','', d)}"


### PR DESCRIPTION
Updates the bmcweb recipe override to pull in the fix for two Redfish privilege-bypass issues, merged upstream in [ocp-hm-openbmc-opf-ami/bmcweb#3](https://github.com/ocp-hm-openbmc-opf-ami/bmcweb/pull/3).