### PR TITLE
Fixed Out-of-Bounds Memory Accesses issues mctp

### DIFF
--- a/meta-common/recipes-phosphor/mctp-i3c-daemon/files/mctp-ctrl-cmds.cpp
+++ b/meta-common/recipes-phosphor/mctp-i3c-daemon/files/mctp-ctrl-cmds.cpp
@@ -1474,6 +1474,22 @@ int getRoutingTableEntries(MctpDevice& device)
         /* Check if the routing table exist */
         if (routingTable->numberOfEntries)
         {
+            size_t headerSize = sizeof(struct mctpCtrlRespGetRoutingTable);
+            if (rxLen < headerSize)
+            {
+                mctpPrErr("%s: response shorter than header", __func__);
+                return -1;
+            }
+            size_t maxPossibleEntries =
+                (rxLen - headerSize) / sizeof(struct getRoutingTableEntry);
+            if (routingTable->numberOfEntries > maxPossibleEntries)
+            {
+                mctpPrErr(
+                    "numberOfEntries (%u) exceeds received data (%zu bytes)",
+                    routingTable->numberOfEntries, rxLen);
+                return -1;
+            }
+
             auto entries = routingTable->numberOfEntries;
             struct getRoutingTableEntry* nextRoutingTableEntry =
                 (struct

--- a/meta-common/recipes-phosphor/mctp-i3c-daemon/files/mctp-i3c-main.cpp
+++ b/meta-common/recipes-phosphor/mctp-i3c-daemon/files/mctp-i3c-main.cpp
@@ -792,6 +792,10 @@ void handleMctpControlCommand(const boost::system::error_code& ec)
                     offsetof(getRoutingTableEntry, physAddressSize);
                 int entry_offset = copy_size + 2;
 
+                const int maxEntries =
+                    (sizeof(buffer) - sizeof(mctpCtrlRespGetRoutingTable)) /
+                    sizeof(getRoutingTableEntry);
+
                 if (mode == MCTP_INTEL_I3C_BRIDGE)
                 {
                     /// If request comes from CPU1 or PFR
@@ -799,7 +803,7 @@ void handleMctpControlCommand(const boost::system::error_code& ec)
                     {
                         /// Traverse the routing table
                         auto tempEntry = g_routing_table_entries;
-                        while (tempEntry != NULL)
+                        while (tempEntry != NULL && entries_count < maxEntries)
                         {
                             if (tempEntry->routeVia != secondaryBusOwnerEid)
                             {
@@ -825,7 +829,7 @@ void handleMctpControlCommand(const boost::system::error_code& ec)
                     {
                         /// If request comes from CPU2
                         auto tempEntry = g_routing_table_entries;
-                        while (tempEntry != NULL)
+                        while (tempEntry != NULL && entries_count < maxEntries)
                         {
                             if (tempEntry->routeVia != busOwnerEid)
                             {
@@ -852,7 +856,7 @@ void handleMctpControlCommand(const boost::system::error_code& ec)
                 {
                     /// Copy entire routing table
                     auto tempEntry = g_routing_table_entries;
-                    while (tempEntry != NULL)
+                    while (tempEntry != NULL && entries_count < maxEntries)
                     {
                         memcpy(&buffer[pos], &tempEntry->routingTable,
                                sizeof(getRoutingTableEntry));


### PR DESCRIPTION
[Summary of work done]
Fixed Out-of-Bounds Memory Accesses issues in mctp i3c daemon

[Issue Description]
Out-of-Bounds Memory Accesses in I3C MCTP Routing Table Handling
[Resolution]
Add a bounds check in the MCTP_CMD_GET_ROUTING_TABLE handler that limits the number of entries copied based on the buffer size and Validate numberOfEntries against the actual received data length in getRoutingTableEntries() before entering the parsing loop

Since this recipe is not enabled in any platform, validation is not possible, but tried compiling the recipe — it is compiling.